### PR TITLE
Backports v0.4.2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,7 +40,7 @@ jobs:
             experimental: true
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,12 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NESSie = "f00e83c4-bd01-11e9-272c-ff1b96fb444d"
 Preconditioners = "af69fa37-3177-5a40-98ee-561f696e4fcd"
 
+[weakdeps]
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+
+[extensions]
+CuNESSieSciMLBaseExt = "SciMLBase"
+
 [compat]
 Adapt = "3.3, 4"
 Aqua = "0.8"
@@ -22,6 +28,7 @@ NESSie = "1.3"
 Preconditioners = "0.3, 0.4, 0.5, 0.6"
 Test = "1.8"
 TestItemRunner = "1"
+SciMLBase = "2, 3"
 julia = "1.8"
 
 [extras]

--- a/ext/CuNESSieSciMLBaseExt.jl
+++ b/ext/CuNESSieSciMLBaseExt.jl
@@ -1,0 +1,60 @@
+module CuNESSieSciMLBaseExt
+
+using NESSie:
+    DoubleLayer,
+    SingleLayer
+using CuNESSie:
+    LaplacePotentialMatrix,
+    LocalSystemMatrix,
+    NonlocalSystemMatrix,
+    ReYukawaPotentialMatrix
+using SciMLBase: AbstractNoTimeSolution
+
+# Avoid method ambiguity (since SciMLBase v3.15.0)
+# https://github.com/SciML/SciMLBase.jl/pull/1365
+@static if hasmethod(Base.:*, Tuple{AbstractMatrix, AbstractNoTimeSolution})
+
+    function Base.:*(
+        A::LaplacePotentialMatrix{T, DoubleLayer},
+        x::AbstractNoTimeSolution{T, 1}
+    ) where T
+        A * x.u
+    end
+
+    function Base.:*(
+        A::LaplacePotentialMatrix{T, SingleLayer},
+        x::AbstractNoTimeSolution{T, 1}
+    ) where T
+        A * x.u
+    end
+
+    function Base.:*(
+        A::LocalSystemMatrix{T},
+        x::AbstractNoTimeSolution{T, 1}
+    ) where T
+        A * x.u
+    end
+
+    function Base.:*(
+        A::NonlocalSystemMatrix{T},
+        x::AbstractNoTimeSolution{T, 1}
+    ) where T
+        A * x.u
+    end
+
+    function Base.:*(
+        A::ReYukawaPotentialMatrix{T, DoubleLayer},
+        x::AbstractNoTimeSolution{T, 1}
+    ) where T
+        A * x.u
+    end
+
+    function Base.:*(
+        A::ReYukawaPotentialMatrix{T, SingleLayer},
+        x::AbstractNoTimeSolution{T, 1}
+    ) where T
+        A * x.u
+    end
+end
+
+end # module


### PR DESCRIPTION
- [x] [build(deps): bump julia-actions/setup-julia from 2 to 3](https://github.com/tkemmer/CuNESSie.jl/commit/90459dc2cc05e482b096b3dd35cc16253b856653)
- [x] [Avoid `Base.:*` ambiguity with SciMLBase](https://github.com/tkemmer/CuNESSie.jl/commit/ecb694c1846b65052b81e61db0491d3dc05a503a)